### PR TITLE
phpinfo() 無効化

### DIFF
--- a/google/debuginfo/index.php
+++ b/google/debuginfo/index.php
@@ -257,7 +257,7 @@ try {
 	$result['last_checkpoint'] = __LINE__;
 
 	header('Content-Type: text/html; charset=UTF-8');
-	phpinfo();
+	echo 'phpinfo() is a deactivated.' ;#phpinfo();
 	exit(0);
 } catch (\Exception $th) {
 	set_http_response_code(500);


### PR DESCRIPTION
再使用時は内部DBのsuper 権限を要する形にする。